### PR TITLE
Use more secure visudo example in comments

### DIFF
--- a/downloads/algorand@.service
+++ b/downloads/algorand@.service
@@ -17,10 +17,10 @@
 ## the algorand systemd service, the following lines need to be added to
 ## /etc/sudoers (using visudo):
 ##
-##   algo ALL=(ALL) NOPASSWD: /usr/bin/systemctl start *
-##   algo ALL=(ALL) NOPASSWD: /usr/bin/systemctl stop *
-##   algo ALL=(ALL) NOPASSWD: /usr/bin/systemctl restart *
-##   algo ALL=(ALL) NOPASSWD: /usr/bin/systemctl status *
+##   algo ALL=(ALL) NOPASSWD: /usr/bin/systemctl start algorand@*
+##   algo ALL=(ALL) NOPASSWD: /usr/bin/systemctl stop algorand@*
+##   algo ALL=(ALL) NOPASSWD: /usr/bin/systemctl restart algorand@*
+##   algo ALL=(ALL) NOPASSWD: /usr/bin/systemctl status algorand@*
 ##
 ## On an Ubuntu machine, replace /usr/bin/systemctl with /bin/systemctl.
 ##


### PR DESCRIPTION
This is the original visudo example in `algorand@.service`:
````
## To allow the update script (which runs as the current user) to manipulate
## the algorand systemd service, the following lines need to be added to
## /etc/sudoers (using visudo):
##
##   algo ALL=(ALL) NOPASSWD: /usr/bin/systemctl start *
##   algo ALL=(ALL) NOPASSWD: /usr/bin/systemctl stop *
##   algo ALL=(ALL) NOPASSWD: /usr/bin/systemctl restart *
##   algo ALL=(ALL) NOPASSWD: /usr/bin/systemctl status *
````

This is pretty bad. I've tested this, and the wildcard lets me interact with **_ANY_** systemd service (with start, stop, restart, and status) as the `algo` user without a password. I also did **_NOT_** add the `algo` user to the sudoers file (as `algo ALL=(ALL) ALL`, or adding `algo` to the `wheel` group ). I was able to stop and start `ip6tables.service` with `sudo /usr/bin/systemctl stop ip6tables` and `sudo /usr/bin/systemctl start ip6tables` respectively. Note that you have to use `sudo /usr/bin/systemctl` and not just `sudo systemctl`. The former is marginally better than the latter.

The following is more secure:

````
## To allow the update script (which runs as the current user) to manipulate
## the algorand-update systemd service, the following lines need to be added to
## /etc/sudoers (using visudo):
##
##   algo ALL=(ALL) NOPASSWD: /usr/bin/systemctl start algorand@*
##   algo ALL=(ALL) NOPASSWD: /usr/bin/systemctl stop algorand@*
##   algo ALL=(ALL) NOPASSWD: /usr/bin/systemctl restart algorand@*
##   algo ALL=(ALL) NOPASSWD: /usr/bin/systemctl status algorand@*
````

You'll still get the wildcard behavior that's needed for user specified directories to work properly with the systemd service. However, it's restricted to the systemd service you needed wildcard'ed in the first place. The `algo` user is going to need to be in the sudoers file and use a password for any other service.

Comparing it to a firewall, it's the difference between opening all ports, vs. just the ones that need opened for a particular task.