### PR TITLE
Add systemd timer and service for algorand auto updates

### DIFF
--- a/downloads/algorand-update@.service
+++ b/downloads/algorand-update@.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=auto-update algorand software under %I
+AssertPathExists=%I
+
+[Service]
+Type=oneshot
+User=algo
+Group=algo
+StandardOutput=file:%Iupdate.log
+StandardError=file:%Iupdate.log
+ExecStart=%Iupdate.sh -d %Idata

--- a/downloads/algorand-update@.timer
+++ b/downloads/algorand-update@.timer
@@ -1,0 +1,42 @@
+## This file should be installed as:
+##
+##   /lib/systemd/system/algorand-update@.timer
+##
+## along with algorand-update@.service as:
+##
+##   /lib/systemd/system/algorand-update@.service
+##
+## and then running "systemctl daemon-reload".
+##
+## To enable and start algorand automatic updates for a particular directory, run:
+##
+##   systemctl enable algorand-update@$(systemd-escape /home/algo/algorand/testnet).timer
+##   systemctl start algorand-update@$(systemd-escape /home/algo/algorand/testnet).timer
+##
+## This assumes a directory layout where the update.sh script lives at
+## /home/user/node/update.sh, and the data lives under
+## /home/user/node/data.
+##
+## To allow the update script (which runs as the current user) to manipulate
+## the algorand-update systemd service, the following lines need to be added to
+## /etc/sudoers (using visudo):
+##
+##   algo ALL=(ALL) NOPASSWD: /usr/bin/systemctl start algorand-update@*
+##   algo ALL=(ALL) NOPASSWD: /usr/bin/systemctl stop algorand-update@*
+##   algo ALL=(ALL) NOPASSWD: /usr/bin/systemctl restart algorand-update@*
+##   algo ALL=(ALL) NOPASSWD: /usr/bin/systemctl status algorand-update@*
+##
+## On an Ubuntu machine, replace /usr/bin/systemctl with /bin/systemctl.
+##
+## We do not use systemd user services because they are disabled in CentOS.
+[Unit]
+Description=auto-update algorand under %I every hour
+
+[Timer]
+# Run hourly
+OnCalendar=*-*-* *:00:00
+Persistent=true
+Unit=algorand-update@.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Now that pull requests are open, I wanted to create a proper pull request instead of just post an issue with my systemd files typed out. The service and timer do more or less the same as what I posted in https://github.com/algorand/go-algorand-doc/issues/13, but with the notable change to be more like the `algorand@.service` file in terms of more generic folder usage/access.