### PR TITLE
add docker devnode build and run

### DIFF
--- a/devnode/Dockerfile
+++ b/devnode/Dockerfile
@@ -1,0 +1,43 @@
+FROM ubuntu:19.04
+
+LABEL maintainer="vincent_serpoul@manulife.com"
+
+RUN mkdir inst
+WORKDIR /inst
+
+COPY ./install_master_linux-amd64.tar.gz /inst/
+
+RUN tar -xf install_master_linux-amd64.tar.gz
+
+RUN apt-get update &&\
+    apt-get install -y ca-certificates
+
+RUN mkdir -p /root/node
+
+RUN ./update.sh -i -c stable -p ~/node -d ~/node/data -n
+
+######
+
+COPY ./genesis.json /root/randpool.genesis.json
+
+# Create randpool network
+RUN /root/node/goal network create -r /root/randpool -n private -t /root/randpool.genesis.json
+
+# desactivate telemetry
+RUN /root/node/diagcfg telemetry disable
+
+# Copy the right config
+# COPY ./nodeconfig.json /root/randpool/Node/config.json
+COPY ./nodeconfig.json /root/randpool/Primary/config.json
+
+VOLUME ["root/randpool"]
+
+COPY ./start.sh /root/start.sh
+
+EXPOSE 7979
+
+WORKDIR /root
+
+ENTRYPOINT ["/root/start.sh"]
+
+# docker build -t randpool/devnode .

--- a/devnode/README.md
+++ b/devnode/README.md
@@ -1,4 +1,55 @@
-# Spinning up a docker dev node
+# Containerized docker algorand private development node
+
+## Description
+
+This folder contains the files necessary to build a container image that can be used to run an algorand private local node.
+Once you have built the image, you can run it and simply connect to the REST API to the port 7979 (see scripts below).
+
+To test if your container is running correctly, you can run this golang source code, which should give you the node status if successful:
+
+```bash
+go run cmd/main.go --token=$(docker exec randpool cat /root/randpool/Primary/algod.token) --port=7979
+```
+
+```golang
+    package main
+
+    import (
+        "flag"
+        "fmt"
+
+        "github.com/algorand/go-algorand-sdk/client/algod"
+    )
+
+    func main() {
+        port := flag.Int("port", 7979, "port used for the REST API")
+        token := flag.String(
+            "token", "-",
+            "token used by the node, docker exec randpool cat /root/randpool/Primary/algod.token",
+        )
+        flag.Parse()
+
+        algodAddress := fmt.Sprintf("http://127.0.0.1:%d", *port)
+        algodToken := *token
+
+        // Create an algod client
+        algodClient, err := algod.MakeClient(algodAddress, algodToken)
+        if err != nil {
+            fmt.Printf("failed to make algod client: %s\n", err)
+            return
+        }
+        // Get algod status
+        nodeStatus, err := algodClient.Status()
+        if err != nil {
+            fmt.Printf("error getting algod status: %s\n", err)
+            return
+        }
+        fmt.Printf("algod last round: %d\n", nodeStatus.LastRound)
+        fmt.Printf("algod time since last round: %d\n", nodeStatus.TimeSinceLastRound)
+        fmt.Printf("algod catchup: %d\n", nodeStatus.CatchupTime)
+        fmt.Printf("algod latest version: %s\n", nodeStatus.LastVersion)
+    }
+```
 
 ## Build
 

--- a/devnode/README.md
+++ b/devnode/README.md
@@ -54,7 +54,7 @@ go run cmd/main.go --token=$(docker exec randpool cat /root/randpool/Primary/alg
 ## Build
 
 ```bash
-docker build -t randpool/devnode:v1.0.0 ./infra/devnode
+docker build -t randpool/devnode:v1.0.0 ./
 ```
 
 ## Run

--- a/devnode/README.md
+++ b/devnode/README.md
@@ -1,0 +1,16 @@
+# Spinning up a docker dev node
+
+## Build
+
+```bash
+docker build -t randpool/devnode:v1.0.0 ./infra/devnode
+```
+
+## Run
+
+```bash
+docker run -dit --name randpool \
+    -p 7979:7979 \
+    --rm \
+    randpool/devnode:v1.0.0
+```

--- a/devnode/genesis.json
+++ b/devnode/genesis.json
@@ -1,0 +1,47 @@
+{
+  "Genesis": {
+    "NetworkName": "rand pool",
+    "Wallets": [
+      {
+        "Name": "Wallet1",
+        "Stake": 50,
+        "Online": true
+      },
+      {
+        "Name": "Wallet2",
+        "Stake": 40,
+        "Online": true
+      },
+      {
+        "Name": "Wallet3",
+        "Stake": 10,
+        "Online": false
+      }
+    ]
+  },
+  "Nodes": [
+    {
+      "Name": "Primary",
+      "IsRelay": true,
+      "Wallets": [
+        {
+          "Name": "Wallet1",
+          "ParticipationOnly": false
+        }
+      ]
+    },
+    {
+      "Name": "Node",
+      "Wallets": [
+        {
+          "Name": "Wallet2",
+          "ParticipationOnly": false
+        },
+        {
+          "Name": "Wallet3",
+          "ParticipationOnly": false
+        }
+      ]
+    }
+  ]
+}

--- a/devnode/nodeconfig.json
+++ b/devnode/nodeconfig.json
@@ -1,0 +1,1 @@
+{ "EndpointAddress": ":7979", "DNSBootstrapID": "", "NetAddress": "127.0.0.1:0" }

--- a/devnode/start.sh
+++ b/devnode/start.sh
@@ -1,0 +1,7 @@
+#! /bin/bash
+
+# start network
+/root/node/goal network start -r /root/randpool -d /root/randpool
+
+# UGLY HACK TODO
+tail -f /dev/null


### PR DESCRIPTION

i did put it raw, there are a few things we can tune first:

* Maintainer label in the Dockerfile - now is vincent_serpoul@manulife.com
* Name, version and tag of the image - now is randpool/devnode:v1.0.0
* Location of the installer - we could/should play with the repositories and use the existing Download folder
* Port number - now set to 7979, as 8080 is very commonly used, especially if you have a docker setup already
* Genesis file may be more suitable in another form

This is a far from optimal setup, ideally, we should have:
* A non root user to run the node
* A long running process that runs the node (instead of tail -f /dev/null)